### PR TITLE
Remove examples submodule from nek5000 subtree.

### DIFF
--- a/3rd_party/nek5000/.gitmodules
+++ b/3rd_party/nek5000/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples"]
-	path = examples
-	url = https://github.com/Nek5000/NekExamples


### PR DESCRIPTION
@RonRahaman and I think this is necessary in order for a recursive submodule update in Cardinal to work correctly. Now that Nek5000 is a subtree in nekRS, but Nek5000/examples is still a submodule in Nek5000, this is confusing the submodule git commands. This PR just removes the examples submodule from Nek5000, which we certainly don't need in Cardinal.