### PR TITLE
Remove no-longer-used OCCA_TAG and NEK5000_TAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ set(OCCA_CXX "${CMAKE_CXX_COMPILER}" CACHE STRING "C++ compiler for OCCA JIT com
 set(OCCA_CXXFLAGS "-O2 -ftree-vectorize -funroll-loops -march=native -mtune=native"
         CACHE STRING "C++ flags for OCCA JIT compile")
 
-set(OCCA_TAG "198772f0178034e6c8577f36eb4b4c6f5dee69e4" CACHE STRING "Git branch, tag, or hash for cloning OCCA")
-set(NEK5000_TAG "ab8ab5699742ca4918eb1f65ff3d5c99a043c1d8" CACHE STRING "Git branch, tag, or hash for cloning Nek5000")
 set(HYPRE_VER "2.20.0" CACHE STRING "Version number of HYPRE to download")
 
 set(USE_OCCA_MEM_BYTE_ALIGN "64" CACHE STRING "Memory allignment for OCCA kernels")


### PR DESCRIPTION
Because Nek5000 and OCCA were replaced in nekRS with git subtrees (as opposed to whatever-is-the-most-recent pull from github directly), we no longer need to take an extra step in our fork to make sure that a fixed version of Nek5000 and OCCA are used. Therefore, we can remove the CMake external project specifiers for Nek5000 and OCCA.